### PR TITLE
Allow external git repos in private mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ registry
     -o, --db-options [value]  Database options
     -p, --port <value>        Web server port
     -h, --host [value]        Web server host
-    -P, --private             Accept private packages
+    -P, --private             Accept private packages and allow packages hosted on private servers
 ```
 
 ### Example

--- a/lib/package.js
+++ b/lib/package.js
@@ -19,6 +19,9 @@ Package.prototype = {
     if (typeof this.url !== 'string')
       errors.push('url is not a string');
 
+    if (options.private && this.url && this.url.match(/\.git$/))
+        return errors.length ? errors : false;
+
     if (this.url && ! this.url.match(/^git((\:\/\/)|@)/))
       errors.push('url is not a git url');
 

--- a/test/package.js
+++ b/test/package.js
@@ -60,6 +60,14 @@ describe('Package', function () {
             this.pkg.validate().should.include.members(['private url is not accepted']);
           });
         });
+
+        describe('with a ssh git url', function () {
+          it('should throw an exception', function () {
+            this.pkg.name = 'test';
+            this.pkg.url = 'ssh://custom-host.com/jquery/metrics.git';
+            this.pkg.validate().should.include.members(['url is not a git url']);
+          });
+        });
       });
 
       describe('with private flag', function () {
@@ -67,6 +75,30 @@ describe('Package', function () {
           it('should not throw an exception', function () {
             this.pkg.name = 'jquery';
             this.pkg.url = 'git@github.com:jquery/jquery.git';
+            this.pkg.validate({private: true}).should.equal(false);
+          });
+        });
+
+        describe('with a ssh url', function () {
+          it('should not throw an exception', function () {
+            this.pkg.name = 'test';
+            this.pkg.url = 'ssh://custom-host.com/jquery/metrics.git';
+            this.pkg.validate({private: true}).should.equal(false);
+          });
+        });
+
+        describe('with a https url', function () {
+          it('should not throw an exception', function () {
+            this.pkg.name = 'test';
+            this.pkg.url = 'https://custom-host.com/jquery/metrics.git';
+            this.pkg.validate({private: true}).should.equal(false);
+          });
+        });
+
+        describe('with a http url', function () {
+          it('should not throw an exception', function () {
+            this.pkg.name = 'test';
+            this.pkg.url = 'http://custom-host.com/jquery/metrics.git';
             this.pkg.validate({private: true}).should.equal(false);
           });
         });


### PR DESCRIPTION
I changed the validation logic to allow repos such as 'ssh://custom-host.com/jquery/metrics.git' when private flag is set. 

 The new validation logic will short circuit if the private flag is set and the url ends in '.git'. I added a few new unit tests to make sure the functionality performs as expected. 
