### PR TITLE
Removes requirement private git repository names end with .git

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -19,7 +19,7 @@ Package.prototype = {
     if (typeof this.url !== 'string')
       errors.push('url is not a string');
 
-    if (options.private && this.url && this.url.match(/\.git$/))
+    if (options.private && this.url)
         return errors.length ? errors : false;
 
     if (this.url && ! this.url.match(/^git((\:\/\/)|@)/))


### PR DESCRIPTION
I had a problem getting this registry working with my repositories.  I traced it down to the fact that the package validator is being overly restrictive.  Not all git repository names end with .git.
